### PR TITLE
Fix `binary_search` a.k.a. "Storage Cracker"

### DIFF
--- a/binary_search/test.si
+++ b/binary_search/test.si
@@ -14,37 +14,52 @@ def arch_get_input($scratch_space: [Int], test: Int) Int {
 
 def arch_check_output($scratch_space: [Int], test: Int, input: Int, output: Int) TestResult {
 
-    if scratch_space[MIN] + 1 >= scratch_space[MAX] {
+    if (scratch_space[MIN] == scratch_space[MAX]) && (scratch_space[MIN] == output) {
 
         // The value is pinned down
+        return win
 
-        if scratch_space[MIN] == output {
-            return win
-        }
-
-        scratch_space[OVER] = <Int> (output > scratch_space[MIN])
-
-        return pass
     }
 
+    // If the player guessed below the interval where the correct value could possibly be found.
     if output < scratch_space[MIN] {
+
         scratch_space[OVER] = 0
 
-    } elif output > scratch_space[MAX] {
+        return pass
+
+    }
+
+    // If the player guessed above the interval where the correct value could possibly be found.
+    if output > scratch_space[MAX] {
+
+        scratch_space[OVER] = 1
+
+        return pass
+
+    }
+
+    // Getting a sample from the interval [min .. max - 1] may seem unintuitive,
+    // but it makes the selection fair (i.e. more correct) and does away with an edge case.
+    // The reason is that any of the comparisons "<", ">", "<=" or ">=" (of which we use ">" below)
+    // splits the interval between two adjacent integers rather than exactly _at_ a single one.
+    // (Or in other words value a cannot be simultaneously > than value b AND NOT > than value b.)
+    let sample = scratch_space[MIN] + random(scratch_space[MAX] - scratch_space[MIN])
+
+    // Select one of the intervals [min .. guess - 1] or [guess + 1 .. max]
+    // probabilistically (with the help of the random sample) based on their relative sizes.
+    if output > sample {
+
+        scratch_space[MAX]  = output - 1
         scratch_space[OVER] = 1
 
     } else {
 
-        let sample = scratch_space[MIN] + random(scratch_space[MAX] - scratch_space[MIN] - 1) + 1
-
-        if output < sample {
-            scratch_space[MIN]  = output + 1
-            scratch_space[OVER] = 1
-        } else {
-            scratch_space[MAX]  = output - 1
-            scratch_space[OVER] = 0
-        }
+        scratch_space[MIN]  = output + 1
+        scratch_space[OVER] = 0
 
     }
+
+    return pass
 
 }


### PR DESCRIPTION
So the actual fix would've just been swapping the 0 and 1 for `OVER` at the end.

Instead, I also fixed the fairness of the interval selection, which automagically simplified the code, eliminating the edge case handling at the top (and the unfairness of always making the lower number correct in that case) and the `- 1` and `+ 1` operations, which are no longer necessary.

The more difficult part is explaining why the new code is better / more correct:

Consider the `MIN` currently being at 100 and the `MAX` currently at 200.
The player guessed 150, which is exactly in the middle and should therefore make the test code pick either of the intervals with the same likelihood.

Now we're choosing a sample randomly, which with the new code can result in a number from _100 .. 199_. The `if` below tests whether the player's guess is strictly greater than the sample (or "above" in x86 parlance, as we only deal with values from 0 to 255, no negatives).
So the guess would test **ABOVE** sample values from _100 .. 149_ and would test **NOT ABOVE** values from _150 .. 199_. Both of these intervals have a cardinality of exactly 50, therefore it will be picked fairly.
