### PR TITLE
Minor correction of function name and signature of `on_reset` in "Calibrating Laser Cannons"

### DIFF
--- a/circumference/test.si
+++ b/circumference/test.si
@@ -1,5 +1,5 @@
 
-def reset(test: Int, $scratch_space: [Int]) {
+def on_reset($scratch_space: [Int], test: Int) {
     ui_set_hidden("note", true)
 }
 


### PR DESCRIPTION
It's probably a leftover from before the rename/re-signature of several Simplex functions. It was simply sleeping there as a user-defined function that no-one ever called.