### PR TITLE
Restore changes in saving_bytes that were likely reverted by accident

### DIFF
--- a/saving_bytes/test.si
+++ b/saving_bytes/test.si
@@ -13,7 +13,7 @@ def get_input($scratch_space: [Int], tick: Int, $inputs: [Int]) {
     .memory = .next_memory
     inputs[3] = .memory
     var action = random(5)
-    var num    = random(255)
+    var num    = random(0x100)
 
     if tick == 0 {
         action = 2
@@ -52,7 +52,7 @@ def check_output($scratch_space: [Int], tick: Int, inputs: [Int], outputs: [Int]
         return fail
     }
 
-    if tick == 64 {
+    if tick == 0xffff {
         return win
     }
 


### PR DESCRIPTION
At some point in December there was a brief time which changed/fixed stuff in `saving_bytes`.

It was likely in response to this discussion: https://discord.com/channels/828292123936948244/1321380258666250260/1321405565888626728

But shortly after the changes were undone, likely by accident, due to some other unrelated problem that required rolling back.
The incident was this one, I believe: https://discord.com/channels/828292123936948244/899582781271736361/1321732353760038946

So here are the changes again.
